### PR TITLE
PyYaml > 6 requires loader argument

### DIFF
--- a/record_fixture.py
+++ b/record_fixture.py
@@ -6,5 +6,5 @@ boids.update_boids(boids.boids)
 after=boids.boids
 fixture={"before":before,"after":after}
 fixture_file=open("fixture.yml",'w')
-fixture_file.write(yaml.dump(fixture))
+fixture_file.write(yaml.safe_dump(fixture))
 fixture_file.close()

--- a/test_boids.py
+++ b/test_boids.py
@@ -4,7 +4,7 @@ import os
 import yaml
 
 def test_bad_boids_regression():
-    regression_data=yaml.load(open(os.path.join(os.path.dirname(__file__),'fixture.yml')))
+    regression_data=yaml.safe_load(open(os.path.join(os.path.dirname(__file__),'fixture.yml')))
     boid_data=regression_data["before"]
     update_boids(boid_data)
     for after,before in zip(regression_data["after"],boid_data):


### PR DESCRIPTION
Just did this for the Turing fork of the material. Replace yaml.load/dump with safe_load / safe_dump. See https://github.com/yaml/pyyaml/issues/576.